### PR TITLE
Fall back to empty string

### DIFF
--- a/resources/js/callbacks.js
+++ b/resources/js/callbacks.js
@@ -50,7 +50,7 @@ Vue.prototype.amFormToVariables = function (form) {
     }
 
     let navigateThrough = (obj, input) => {
-        return input.split('.').reduce((pointer, part) => navigate(pointer, part) ?? navigate(pointer?.addresses?.[0], part), obj)
+        return input.split('.').reduce((pointer, part) => navigate(pointer, part) ?? navigate(pointer?.addresses?.[0] ?? '', part), obj)
     }
 
     let replaceVariables = (value) => {


### PR DESCRIPTION
When a variable doesn't exist, it'll either return `null` or `undefined`, which we don't want. Return an empty string instead so the form doesn't end up looking weird.