### PR TITLE
don't break if custom attribute does not exist

### DIFF
--- a/resources/js/callbacks.js
+++ b/resources/js/callbacks.js
@@ -29,7 +29,7 @@ Vue.prototype.amFormToVariables = function (form) {
         }
 
         if(part.startsWith('custom:')) {
-            return pointer.custom_attributes?.find(attribute => attribute.attribute_code === part.substring(7)).value
+            return pointer.custom_attributes?.find(attribute => attribute.attribute_code === part.substring(7))?.value ?? ''
         }
         switch(part) {
             case 'address':


### PR DESCRIPTION
When the attribute does not exist for the customer, it breaks and does not show the form anymore because `.value` is not defined.